### PR TITLE
Feat: Make Excon instance to accept `ciphers` SSL option (#45)

### DIFF
--- a/faraday-excon.gemspec
+++ b/faraday-excon.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'excon', '>= 0.109.0'
-  spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'faraday', '>= 2.11.0', '< 3'
 end

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -82,6 +82,7 @@ module Faraday
       end
 
       OPTS_KEYS = [
+        %i[ciphers ciphers],
         %i[client_cert client_cert],
         %i[client_key client_key],
         %i[certificate certificate],


### PR DESCRIPTION
This PR is to support ciphers SSL Option usage as mentioned in this PR https://github.com/lostisland/faraday/issues/1586