### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/faraday-excon.gemspec
+++ b/faraday-excon.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.metadata['source_code_uri'] = 'https://github.com/excon/faraday-excon'
   spec.metadata['changelog_uri'] = "https://github.com/excon/faraday-excon/releases/tag/v#{spec.version}"
+  spec.metadata["funding_uri"] = "https://github.com/sponsors/geemus"
 
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']


### PR DESCRIPTION
Similar to https://github.com/excon/excon/pull/875, I noticed that the project already has a FUNDING.yml, this PR adds `funding_uri` to the gemspec to help increase visibility using the `bundle fund` command in Bundler.